### PR TITLE
Fix skipframe issues

### DIFF
--- a/lib/features/learn/learn_topic/screens/topic_sublesson.dart
+++ b/lib/features/learn/learn_topic/screens/topic_sublesson.dart
@@ -4,7 +4,7 @@ import 'package:speak_up/core/constants/asset_color.dart';
 import 'package:speak_up/models/lesson.dart';
 import 'package:speak_up/provider/lesson.dart';
 
-class SubLessonScreen extends StatelessWidget {
+class SubLessonScreen extends StatefulWidget {
   final String parentLessonId;
   final String title;
 
@@ -15,16 +15,30 @@ class SubLessonScreen extends StatelessWidget {
   });
 
   @override
+  State<SubLessonScreen> createState() => _SubLessonScreenState();
+}
+
+class _SubLessonScreenState extends State<SubLessonScreen> {
+  late Future<List<LessonModel>> _subLessonsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _subLessonsFuture =
+        context.read<LessonProvider>().fetchSubLessons(widget.parentLessonId);
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(title, style: const TextStyle(color: Colors.white)),
+        title: Text(widget.title, style: const TextStyle(color: Colors.white)),
         backgroundColor: AppColors.background,
         iconTheme: const IconThemeData(color: Colors.white),
       ),
       backgroundColor: AppColors.background,
       body: FutureBuilder<List<LessonModel>>(
-        future: context.read<LessonProvider>().fetchSubLessons(parentLessonId),
+        future: _subLessonsFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return const Center(child: CircularProgressIndicator());

--- a/lib/features/splash/screens/home_screen.dart
+++ b/lib/features/splash/screens/home_screen.dart
@@ -2,14 +2,27 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:speak_up/core/routing/route_names.dart';
 
-class SplashScreen extends StatelessWidget {
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 3), () {
+      if (mounted) {
+        GoRouter.of(context).go(RouteNames.register);
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    Future.delayed(const Duration(seconds: 3), () {
-      GoRouter.of(context).go(RouteNames.register);
-    });
-
-    return Scaffold(
+    return const Scaffold(
       body: Center(child: Text('Loading...', style: TextStyle(fontSize: 24))),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -54,44 +54,10 @@ class MyApp extends StatelessWidget {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       routerConfig: AppRouter.router,
-      // Thêm theme tối ưu hóa
       theme: ThemeData(
         useMaterial3: true,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      // Màn hình chờ khi khởi tạo
-      builder: (context, child) {
-        return FutureBuilder(
-          future: Future.wait([
-            Firebase.initializeApp(),
-            dotenv.load(fileName: ".env"),
-          ]),
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const MaterialApp(
-                debugShowCheckedModeBanner: false,
-                home: Scaffold(
-                  body: Center(child: CircularProgressIndicator()),
-                ),
-              );
-            }
-            if (snapshot.hasError) {
-              return MaterialApp(
-                debugShowCheckedModeBanner: false,
-                home: Scaffold(
-                  body: Center(
-                    child: Text(
-                      'Lỗi khởi tạo: ${snapshot.error}',
-                      style: const TextStyle(color: Colors.red),
-                    ),
-                  ),
-                ),
-              );
-            }
-            return child!;
-          },
-        );
-      },
     );
   }
 }

--- a/lib/provider/topic.dart
+++ b/lib/provider/topic.dart
@@ -57,10 +57,15 @@ class TopicProvider extends ChangeNotifier {
 
       debugPrint("📦 Có ${topics.length} topic (section = topic)");
 
-      for (final topic in topics) {
-        final topicId = topic.id;
-        final lessonRes =
-            await _dio.get('/lesson/getLessonByParentTopicId/$topicId');
+      final lessonResponses = await Future.wait(
+        topics.map(
+          (t) => _dio.get('/lesson/getLessonByParentTopicId/${t.id}'),
+        ),
+      );
+
+      for (var i = 0; i < topics.length; i++) {
+        final topicId = topics[i].id;
+        final lessonRes = lessonResponses[i];
         final data = lessonRes.data['rs'] ?? [];
 
         final parentLessons = (data as List)
@@ -70,7 +75,7 @@ class TopicProvider extends ChangeNotifier {
 
         topicLessons[topicId] = parentLessons;
 
-        debugPrint("✅ ${topic.title} có ${parentLessons.length} bài học cha");
+        debugPrint("✅ ${topics[i].title} có ${parentLessons.length} bài học cha");
       }
 
       _generateTrendingLessons();


### PR DESCRIPTION
## Summary
- convert `SplashScreen` to a StatefulWidget so the timer only runs once
- fetch sub lessons once in `SubLessonScreen`
- cache sub lesson counts in `TopicDetailScreen`
- remove redundant initialization from `MyApp`
- fetch lesson lists in parallel in `TopicProvider`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c71a98588333a1ed14ec54304d13