### PR TITLE
Fix STT recorder timing

### DIFF
--- a/lib/features/learn/learn_lesson/screens/lesson_vocab.dart
+++ b/lib/features/learn/learn_lesson/screens/lesson_vocab.dart
@@ -251,8 +251,6 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
                                           expectedWord: vocab.word,
                                           onResult: (success, spoken,
                                               confidence, feedback) async {
-                                            await speechProvider
-                                                .stopListeningManually();
                                             if (mounted) {
                                               setState(() {
                                                 _isCorrect = success;
@@ -264,6 +262,13 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
                                                     const SnackBar(
                                                         content: Text(
                                                             'Không nhận diện được giọng nói.')),
+                                                  );
+                                                } else {
+                                                  ScaffoldMessenger.of(context)
+                                                      .showSnackBar(
+                                                    const SnackBar(
+                                                        content: Text(
+                                                            'Đang ghi âm để chấm điểm, hãy đọc lại...')),
                                                   );
                                                 }
                                               });


### PR DESCRIPTION
## Summary
- avoid microphone conflict by starting recorder after speech recognition finishes
- show snackbar prompting user to repeat so the app can record

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843cc0ec4fc8333a2cb221a3d99c82c