### PR TITLE
Add spoken word display to vocabulary lessons

### DIFF
--- a/lib/features/learn/learn_lesson/screens/lesson_vocab.dart
+++ b/lib/features/learn/learn_lesson/screens/lesson_vocab.dart
@@ -29,6 +29,7 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
   late final PageController _pageController;
   int _currentIndex = 0;
   bool _isCorrect = false;
+  String _spokenWord = '';
   String _feedback = '';
 
   @override
@@ -136,6 +137,7 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
       setState(() {
         _currentIndex++;
         _isCorrect = false;
+        _spokenWord = '';
         _feedback = '';
       });
       _pageController.animateToPage(
@@ -180,6 +182,7 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
                           setState(() {
                             _currentIndex = index;
                             _isCorrect = false;
+                            _spokenWord = '';
                             _feedback = '';
                           });
                           final audio = vocabList[index].audioUrl;
@@ -191,6 +194,7 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
                         isListening: speechProvider.isListening,
                         confidenceLevel: speechProvider.confidenceLevel,
                         accuracy: speechProvider.accuracy,
+                        spokenWord: _spokenWord,
                         feedback: _feedback,
                         onPlayAudio: () {
                           final audioUrl = vocabList[index].audioUrl ?? '';
@@ -255,6 +259,7 @@ class _VocabularyListScreenState extends State<VocabularyListScreen> {
                                                 .stopListeningManually();
                                             if (mounted) {
                                               setState(() {
+                                                _spokenWord = spoken;
                                                 _isCorrect = success;
                                                 _feedback = feedback;
                                                 if (!success &&

--- a/lib/features/learn/learn_lesson/widgets/vocab_card.dart
+++ b/lib/features/learn/learn_lesson/widgets/vocab_card.dart
@@ -9,6 +9,7 @@ class VocabularyCard extends StatelessWidget {
   final double confidenceLevel;
   final double? accuracy;
   final String feedback;
+  final String spokenWord;
   final VoidCallback onPlayAudio;
   final VoidCallback onPlaySlowAudio;
 
@@ -18,6 +19,7 @@ class VocabularyCard extends StatelessWidget {
     required this.confidenceLevel,
     this.accuracy,
     required this.feedback,
+    required this.spokenWord,
     required this.onPlayAudio,
     required this.onPlaySlowAudio,
   });
@@ -88,6 +90,13 @@ class VocabularyCard extends StatelessWidget {
                     padding: const EdgeInsets.only(top: 4),
                     child: Text(feedback,
                         style: const TextStyle(color: Colors.red)),
+                  ),
+                if (spokenWord.isNotEmpty)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 4),
+                    child: Text('Bạn nói: $spokenWord',
+                        style: const TextStyle(
+                            fontSize: 16, color: Colors.blue)),
                   ),
               ],
             ),


### PR DESCRIPTION
## Summary
- store user spoken word in lesson vocab screen state
- pass spoken word to `VocabularyCard`
- show the spoken word on each vocabulary card when available

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843d31204008333aa5be01bd137f1e8